### PR TITLE
removing alert statements from user facing pages

### DIFF
--- a/src/features/events/eventsSlice.ts
+++ b/src/features/events/eventsSlice.ts
@@ -40,7 +40,6 @@ const eventsSlice = createSlice({
             state.isLoading = false;
         },
         [getAllEvents.rejected.toString()]: (state: EventsState, action: PayloadAction<string>) => {
-            alert(action.payload);
             state.isLoading = false;
         }
     }

--- a/src/features/news/newsSlice.ts
+++ b/src/features/news/newsSlice.ts
@@ -40,7 +40,6 @@ const newsSlice = createSlice({
             state.isLoading = false;
         },
         [getAllNews.rejected.toString()]: (state: NewsState, action: PayloadAction<string>) => {
-            alert(action.payload);
             state.isLoading = false;
         }
     }


### PR DESCRIPTION
## Descriptions
Hello, I'm Janney's friend. I stumbled across by the team's website and found a public facing bug where the alert pop-up was showing on the About, Event, and News Page.

## Bug Screenshots
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/a0c23ab9-ad80-49a2-9249-9592ef26ca6c" />

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/eec5f45e-3898-40b3-a2c4-82b3b4d4479e" />

<img width="1710" alt="image" src="https://github.com/user-attachments/assets/942005a2-482d-4a1b-adf7-cbe97cfa7ae7" />

